### PR TITLE
Fix house color

### DIFF
--- a/docs/geojson_spec.md
+++ b/docs/geojson_spec.md
@@ -21,7 +21,7 @@ Houses include all objects, of which the boundaries should be drawn onto the map
 - File: `house.geojson.gz`
 - Geometry-Type: [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6)
 - Properties:
-    - `color`: Array of four integers from 0 to 255 `[red, green, blue, alpha]`
+    - `color`: Array of three integers from 0 to 255 `[red, green, blue]`
 
 ## 5. Rocks
 Rocks are [those grey areas](./assets/rocks.png) that are drawn onto the ingame map.

--- a/src/geojsons.cpp
+++ b/src/geojsons.cpp
@@ -107,7 +107,7 @@ void writeHouses(grad_aff::Wrp& wrp, std::filesystem::path& basePathGeojson)
             // make sure every color-value is below or equal to 128
             if (*maxColorValue > 128) {
                 float_t factor = 128.0f / *maxColorValue;
-                
+
                 std::transform(color.begin(), color.end(), color.begin(), [factor](uint8_t value) { return (uint8_t)std::round(factor * value);  });
             }
 

--- a/src/geojsons.cpp
+++ b/src/geojsons.cpp
@@ -105,10 +105,10 @@ void writeHouses(grad_aff::Wrp& wrp, std::filesystem::path& basePathGeojson)
             auto maxColorValue = std::max_element(std::begin(color), std::end(color));
 
             // make sure every color-value is below or equal to 128
-            if (maxColorValue > 128) {
-                float_t factor = 128.0f / maxColorValue;
-
-                std::transform(color.begin(), color.end(), [](uint8_t value) { return (uint8_t)std::round(factor * value);  });
+            if (*maxColorValue > 128) {
+                float_t factor = 128.0f / *maxColorValue;
+                
+                std::transform(color.begin(), color.end(), color.begin(), [factor](uint8_t value) { return (uint8_t)std::round(factor * value);  });
             }
 
             mapFeature["properties"] = { { "color", color } };


### PR DESCRIPTION
This PR makes sure the colors exported in the `house.geojson.gz` match the colors displayed on the ingame map.

_Little disclaimer: I actually don't know if this runs, because I couldn't compile grad_meh with my current setup ^^_