### PR TITLE
Make sure poygons comply to geojson spec

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ if (NOT TARGET Libsquish::Libsquish)
         IMPORTED_LOCATION "${LIBSQUISH_LIBRARIES}")
 endif ()
 
+find_package(OpenEXR CONFIG)
 find_package(OpenImageIO CONFIG REQUIRED)
 
 # GADL

--- a/src/geojsons.cpp
+++ b/src/geojsons.cpp
@@ -79,6 +79,7 @@ void writeHouses(grad_aff::Wrp& wrp, std::filesystem::path& basePathGeojson)
             coordArr.push_back(std::vector<float_t> { mapInfo4Ptr->bounds[2], mapInfo4Ptr->bounds[3] });
             coordArr.push_back(std::vector<float_t> { mapInfo4Ptr->bounds[6], mapInfo4Ptr->bounds[7] });
             coordArr.push_back(std::vector<float_t> { mapInfo4Ptr->bounds[4], mapInfo4Ptr->bounds[5] });
+            coordArr.push_back(std::vector<float_t> { mapInfo4Ptr->bounds[0], mapInfo4Ptr->bounds[1] });
 
             auto outerArr = nl::json::array();
             outerArr.push_back(coordArr);
@@ -536,6 +537,7 @@ nl::json buildRunwayPolygon(sqf::config_entry& runwayConfig) {
     coordArr.push_back({ startPos[0] - px, startPos[1] - py });
     coordArr.push_back({ endPos[0] - px, endPos[1] - py });
     coordArr.push_back({ endPos[0] + px, endPos[1] + py });
+    coordArr.push_back({ startPos[0] + px, startPos[1] + py });
 
     auto outerArr = nl::json::array();
     outerArr.push_back(coordArr);


### PR DESCRIPTION
I noticed that some polygons in our GeoJSONs don't comply to the GeoJSON specification. (See [GeoJSON specification section 3.1.6](https://tools.ietf.org/html/rfc7946#section-3.1.6))

The spec sates: 
> [...]For type "Polygon", the "coordinates" member MUST be an array of linear ring coordinate arrays. [...]

A linear ring is further specified:
> [...]
> - A linear ring is a closed LineString with four or more positions.
> 
> - The first and last positions are equivalent, and they MUST contain identical values; their representation SHOULD also be identical.
> 
> - A linear ring is the boundary of a surface or the boundary of a hole in a surface.
> 
> - A linear ring MUST follow the right-hand rule with respect to the area it bounds, i.e., exterior rings are counterclockwise, and holes are clockwise.
>
> Note: the [[GJ2008](https://tools.ietf.org/html/rfc7946#ref-GJ2008)] specification did not discuss linear ring winding order.  For backwards compatibility, parsers SHOULD NOT reject Polygons that do not follow the right-hand rule.
> [...]

This PR makes sure our polygons follow all the rules expect the last one.
In a perfect world we would make sure that all polygons also follow the the right hand rule, but I think because of the note we can get away with just hoping that they do. ^^ Even if they don't it shouldn't be a big problem, because we don't have any polygons with holes.