### PR TITLE
docs: Adjust geojson docs

### DIFF
--- a/docs/geojson_spec.md
+++ b/docs/geojson_spec.md
@@ -3,12 +3,14 @@
 ## 1. Introduction
 This specification outlines the exact structure of the `geojson/` directory of a map.
 
-## 2. General
 The `geojson/` directory holds the vector data of all objects and locations as multiple [geojson files](https://en.wikipedia.org/wiki/GeoJSON).  
-Each file is gzipped and holds an array of [geojson features](https://tools.ietf.org/html/rfc7946#section-3.2).  
-Not every map has every type of object/location therefore the `geojson/` directory may include all, some or even none of the files specified below. For example Stratis doesn't include any fountains; ergo the `fountain.geojson.gz` is omitted entirely.
+Each file is gzipped and holds an array of [geojson features](https://tools.ietf.org/html/rfc7946#section-3.2). All coordinates are in Arma 3's coordinate reference system.  
 
-## 3. Generic Objects
+> [!IMPORTANT]
+> Not every map has every type of object/location therefore the `geojson/` directory may include all, some or even none of the files specified below.  
+> For example Stratis doesn't include any fountains; ergo the `fountain.geojson.gz` is omitted entirely. 
+
+## 2. Generic Objects
 Generic objects include all objects that are represented by an icon on the ingame map. Each object type has its own file.  
 We export the following types: `bunker`, `chapel`, `church`, `cross`, `fuelstation`, `lighthouse`, `rock`, `shipwreck`, `transmitter`, `watertower`, `fortress`, `fountain`, `view-tower`, `quay`, `hospital`, `busstop`, `stack`, `ruin`, `tourism`, `powersolar`, `powerwave`, `powerwind`, `tree`, `bush`
 
@@ -16,7 +18,7 @@ We export the following types: `bunker`, `chapel`, `church`, `cross`, `fuelstati
 - Geometry-Type: [Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)
 - Properties: none
 
-## 4. Houses
+## 3. Houses
 Houses include all objects, of which the boundaries should be drawn onto the map. 
 
 - File: `house.geojson.gz`
@@ -26,34 +28,34 @@ Houses include all objects, of which the boundaries should be drawn onto the map
     - `height`: Bounding box height in meters
     - `position`: Array of three floats `[x, y, z]`
 
-## 5. Rocks
+## 4. Rocks
 Rocks are [those grey areas](./assets/rocks.png) that are drawn onto the ingame map.
 - File: `rocks.geojson.gz`
 - Geometry-Type: [MultiPolygon](https://tools.ietf.org/html/rfc7946#section-3.1.7)
 - Properties: none
 
-## 6. Forests
-Similar to [Rocks](#Rocks), Forests include the green areas that are drawn onto the ingame map.
+## 5. Forests
+Similar to [Rocks](#4-rocks), Forests include the green areas that are drawn onto the ingame map.
 - File: `forest.geojson.gz`
 - Geometry-Type: [MultiPolygon](https://tools.ietf.org/html/rfc7946#section-3.1.7)
 - Properties: none
 
-## 7. Railways
+## 6. Railways
 - File: `railway.geojson.gz`
 - Geometry-Type: [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4)
 - Properties: none
 
-## 8. Power Lines
+## 7. Power Lines
 - File: `powerline.geojson.gz`
 - Geometry-Type: [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4)
 - Properties: none
 
-## 9. Runways
+## 8. Runways
 - File: `runway.geojson.gz`
 - Geometry-Type: [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6)
 - Properties: none
 
-## 10. Locations
+## 9. Locations
 Arma 3 suports a lot of different [location types](https://community.bistudio.com/wiki/Location#Location_Types). Each type has its own file in the `locations/` subdirectory. The filename corresponds to the lowercase location type.  
 → All locations of type `NameLocal` can be found in `locations/namelocal.geojson.gz`
 
@@ -65,7 +67,7 @@ Arma 3 suports a lot of different [location types](https://community.bistudio.co
     - `radiusA`: Corresponds to value in map config
     - `radiusB`: Corresponds to value in map config
 
-## 11. Roads
+## 10. Roads
 Arma 3 splits roads into different types. These types are usually only `main_road`, `road`, `track` and `trail` but this may be subject to change with new/modded maps. Each road type has its own file in the `roads/` subdirectory. The filename corresponds to the lowercase road type.  
 → All roads of type `main_road` can be found in `roads/main_road.geojson.gz`
 
@@ -74,21 +76,24 @@ Arma 3 splits roads into different types. These types are usually only `main_roa
 - Properties:
     - `width`: Width factor of road (is extracted from `RoadsLib.cfg`)
 
-## 12. Bridges
-Bridges can be split in the same categories as [roads](#11-roads). Like [roads](#11-roads) they can be found in the `roads/` subdirectory and the filename also corresponds to the lowercase road type but with a `-bridge` suffix.  
+## 11. Bridges
+Bridges can be split in the same categories as [roads](#10-roads). Like [roads](#10-roads) they can be found in the `roads/` subdirectory and the filename also corresponds to the lowercase road type but with a `-bridge` suffix.  
 → All bridges of type `track` can be found in `roads/track-bridge.geojson.gz`
 
 - File: `roads/<ROAD_TYPE>-bridge.geojson.gz`
 - Geometry-Type: [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6)
 - Properties: none
 
-## 13. Rivers
-Only includes `MapType` `river` objects [introduced in February 2023](https://dev.arma3.com/post/techrep-00053). Weferlingen is the only map known to use these.
+## 12. Rivers
+> [!NOTE]
+> This includes only objects of MapType `river`, [introduced in February 2023](https://dev.arma3.com/post/techrep-00053) to enable terrain builders to place water at elevations different from ASL=0.  
+> Weferlingen is the only known map utilizing this feature. Many other maps simulate rivers using the sea, which will not appear here but rather in the [digital elevation model](./output_spec.md#6-demascgz) at z=0.
+
 - File: `river.geojson.gz`
 - Geometry-Type: [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6)
 - Properties: none
 
-## 14. Mounts
+## 13. Mounts
 - File: `mounts.geojson.gz`
 - Geometry-Type: [Point](https://tools.ietf.org/html/rfc7946#section-3.1.2)
 - Properties:


### PR DESCRIPTION
This PR adjusts the GeoJSON docs:
- Use of [markdown alerts](https://github.com/orgs/community/discussions/16925) to emphasize note on map type `river`
- Add clarification about CRS for all coordinates
- Merged "General" section into Introduction section 